### PR TITLE
Support email lang param

### DIFF
--- a/email/muistot_mailers/zoner.py
+++ b/email/muistot_mailers/zoner.py
@@ -99,12 +99,13 @@ class ZonerMailer(Mailer):
     def get_sender(self):
         return f"Muistotkartalla <{self.config.sender}>"
 
-    ''' **** Needs to be updated, lang is not given as an argument, has to default to english ****'''
-
     def handle_login_data(self, user: str, token: str, verified: bool, lang: str = "en", **_):
         from urllib.parse import urlencode
-        url = urlencode(dict(user=user, token=token,
-                        verified=f'{bool(verified)}'.lower()))
+        url = urlencode(dict(
+            user=user,
+            token=token,
+            verified=f'{bool(verified)}'.lower()),
+        )
         url = f'{self.config.service_url}#email-login:{url}'
 
         if lang == "fi":
@@ -118,12 +119,13 @@ class ZonerMailer(Mailer):
 
         return subject, text, html
 
-    ''' **** Needs to be updated, lang is not given as an argument (?), has to default to english ****'''
-
     def handle_verify_data(self, user: str, token: str, verified: bool, lang: str = "en", **_):
         from urllib.parse import urlencode
-        url = urlencode(dict(user=user, token=token,
-                        verified=f'{bool(verified)}'.lower()))
+        url = urlencode(dict(
+            user=user,
+            token=token,
+            verified=f'{bool(verified)}'.lower()),
+        )
         url = f'{self.config.service_url}#verify-user:{url}'
 
         if lang == "fi":

--- a/src/muistot/login/logic/email.py
+++ b/src/muistot/login/logic/email.py
@@ -27,10 +27,17 @@ async def create_email_verifier(username: str, db: Database) -> Tuple[str, str, 
     return m[0], token, m[1]
 
 
-async def send_login_email(username: str, db: Database):
+async def send_login_email(username: str, db: Database, lang: str):
     email, token, verified = await create_email_verifier(username, db)
     mailer = get_mailer()
-    await mailer.send_email(email, "login", user=username, token=token, verified=verified)
+    await mailer.send_email(
+        email,
+        "login",
+        user=username,
+        token=token,
+        verified=verified,
+        lang=lang,
+    )
 
 
 async def can_send_email(email: str, db: Database):
@@ -56,7 +63,7 @@ async def fetch_user_by_email(email: str, db: Database) -> Optional[str]:
     )
 
 
-async def send_confirm_email(username: str, db: Database):
+async def send_confirm_email(username: str, db: Database, lang: str):
     from ...mailer import get_mailer
 
     code = create_code()
@@ -77,7 +84,8 @@ async def send_confirm_email(username: str, db: Database):
         "register",
         user=username,
         token=code,
-        verified=False
+        verified=False,
+        lang=lang,
     )
 
 

--- a/src/muistot/login/providers/_default.py
+++ b/src/muistot/login/providers/_default.py
@@ -4,6 +4,7 @@ from ..logic.login import register_user, confirm, password_login
 from ..logic.models import LoginQuery, RegisterQuery
 from ...database import Database, Databases
 from ...security import disallow_auth
+from ...backend.repos.base.utils import extract_language
 
 router = APIRouter()
 
@@ -36,8 +37,8 @@ async def default_login(r: Request, login: LoginQuery, db: Database = Depends(Da
     status_code=201,
 )
 @disallow_auth
-async def default_register(query: RegisterQuery, db: Database = Depends(Databases.default)):
-    return await register_user(query, db)
+async def default_register(r: Request, query: RegisterQuery, db: Database = Depends(Databases.default)):
+    return await register_user(query, db, lang=extract_language(r, default_on_invalid=True))
 
 
 @router.post(

--- a/src/muistot/login/providers/_email_only.py
+++ b/src/muistot/login/providers/_email_only.py
@@ -7,6 +7,7 @@ from ..logic.models import EmailStr
 from ..logic.utils import ratelimit_via_redis_host_and_key
 from ...database import Databases, Database
 from ...security import disallow_auth
+from ...backend.repos.base.utils import extract_language
 
 router = APIRouter(tags=["Auth"])
 
@@ -24,7 +25,7 @@ router = APIRouter(tags=["Auth"])
 @disallow_auth
 async def email_only_login(r: Request, email: EmailStr, db: Database = Depends(Databases.default)):
     ratelimit_via_redis_host_and_key(r, email)
-    return await email_login(email, db)
+    return await email_login(email, db, lang=extract_language(r, default_on_invalid=True))
 
 
 @router.post(

--- a/src/test/server/backend/test_utils.py
+++ b/src/test/server/backend/test_utils.py
@@ -1,8 +1,10 @@
 import pytest
 from fastapi import HTTPException, status
 from headers import ACCEPT_LANGUAGE, CONTENT_LANGUAGE
-from muistot.backend.repos.base.utils import extract_language, check_language, not_implemented
 from starlette.authentication import UnauthenticatedUser
+
+from muistot.backend.repos.base.utils import extract_language, check_language, not_implemented
+from muistot.config import Config
 
 
 class MockRequest:
@@ -21,7 +23,7 @@ class MockRequest:
         ("en-US,en;q=0.5", "en"),
         ("az,bg,yf,en-US,en;q=0.5", "en"),
         ("az,bg,yf,fi-AA,en-US,en;q=0.5", "fi"),
-        (None, "fi"),
+        (None, Config.localization.default),
         ("", "fi"),
     ],
 )
@@ -73,3 +75,18 @@ async def test_not_implemented():
         await mock()
 
     assert e.value.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+def test_get_language_no_throw():
+    r = MockRequest()
+    r.method = "GET"
+    r.headers["Muistot-Language"] = "wDwwDWDDwDawdwa"
+
+    assert extract_language(r, default_on_invalid=True) == Config.localization.default
+
+    r = MockRequest()
+    r.method = "POST"
+
+    r.headers["Muistot-Language"] = "dwadwadwadwajdwadhwau"
+
+    assert extract_language(r, default_on_invalid=True) == Config.localization.default


### PR DESCRIPTION
Adds:
- Header `Muistot-Language` to override other language related headers
- Support for email languages from request